### PR TITLE
chore(travis): set build version to latest LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "v10.12.0"
+  - "lts/*"
 
 matrix:
   include:


### PR DESCRIPTION
Right now the latest Node.js LTS version is `v10.13.0` and I think we should use the LTS from now onwards. Especially because [`node-pre-gyp` doesn't work on Node.js `v11.0.0`](https://github.com/mapbox/node-pre-gyp/issues/421) for now.

For updating Node.js I recommend:
- [chocolatey](https://chocolatey.org/packages/nodejs) on Windows
- and [NVM](https://github.com/creationix/nvm) on every other OS