### PR TITLE
chore(docker): simnet for integration tests

### DIFF
--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -4,10 +4,10 @@ FROM golang:1.11.1-alpine as builder
 RUN apk update && apk upgrade && apk add --no-cache git make
 
 # Install LND
-RUN git clone https://github.com/lightningnetwork/lnd $GOPATH/src/github.com/lightningnetwork/lnd
+RUN git clone https://github.com/ExchangeUnion/lnd.git $GOPATH/src/github.com/lightningnetwork/lnd
 
 WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
-RUN git checkout v0.5-beta && make dep && make install
+RUN git checkout resolver+simnet-ltcd && make dep && make install
 
 # Start again with a new image to reduce the size
 FROM alpine:3.8 as final

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "docker-start": "docker-compose -f test/integration/docker-compose.yml up -d",
     "docker-stop": "docker-compose -f test/integration/docker-compose.yml down -v",
     "test": "npm run test:unit && npm run test:int",
-    "test:int": "npm run docker-start && mocha test/integration/chain/*.spec.ts test/integration/lightning/*.spec.ts test/integration/swap/*.spec.ts test/integration/wallet/*.spec.ts && npm run docker-stop",
+    "test:int": "npm run test:int:nostop && npm run docker-stop",
+    "test:int:nostop": "npm run docker-start && mocha test/integration/chain/*.spec.ts test/integration/lightning/*.spec.ts test/integration/swap/*.spec.ts test/integration/wallet/*.spec.ts",
     "test:unit": "mocha test/unit/*.spec.ts test/unit/swap/*.spec.ts test/unit/wallet/*.spec.ts"
   },
   "bin": {

--- a/test/integration/chain/ChainClient.spec.ts
+++ b/test/integration/chain/ChainClient.spec.ts
@@ -11,14 +11,14 @@ describe('ChainClient', () => {
   });
 
   it('BtcdClient should activate SegWit', async () => {
-    // 433 blocks are needed to active SegWit on the BTCD regtest network
+    // 433 blocks are needed to active SegWit on the BTCD simnet network
     const blockHashes = await btcdClient.generate(433);
 
     const block = await btcdClient.getBlock(blockHashes[0]);
     const rawTransaction = await btcdClient.getRawTransaction(block.tx[0]);
     const transaction = Transaction.fromHex(rawTransaction);
 
-    btcManager = new UtxoManager(btcdClient, Networks.bitcoinRegtest, {
+    btcManager = new UtxoManager(btcdClient, Networks.bitcoinSimnet, {
       hash: transaction.getId(),
       value: transaction.outs[0].value,
     });
@@ -26,14 +26,17 @@ describe('ChainClient', () => {
 
   it('LtcdClient should connect', async () => {
     await ltcdClient.connect();
+  });
 
-    const blockHash = await ltcdClient.generate(1);
+  it('LtcdClient should activate SegWit', async () => {
+    // 433 blocks are needed to active SegWit on the BTCD simnet network
+    const blockHashes = await ltcdClient.generate(433);
 
-    const block = await ltcdClient.getBlock(blockHash[0]);
+    const block = await ltcdClient.getBlock(blockHashes[0]);
     const rawTransaction = await ltcdClient.getRawTransaction(block.tx[0]);
     const transaction = Transaction.fromHex(rawTransaction);
 
-    ltcManager = new UtxoManager(ltcdClient, Networks.litecoinRegtest, {
+    ltcManager = new UtxoManager(ltcdClient, Networks.litecoinSimnet, {
       hash: transaction.getId(),
       value: transaction.outs[0].value,
     });
@@ -73,11 +76,11 @@ type Utxo = {
   value: number;
 };
 
-class UtxoManager {
+export class UtxoManager {
   private keys: ECPair;
 
   constructor(private chainClient: ChainClient, private network: Network, private utxo: Utxo) {
-    this.keys = network === Networks.bitcoinRegtest ? btcKeys : ltcKeys;
+    this.keys = network === Networks.bitcoinSimnet ? btcKeys : ltcKeys;
   }
 
   public constructTransaction = (destinationAddress: string, value: number): Transaction => {
@@ -109,17 +112,17 @@ class UtxoManager {
   }
 }
 
-export const btcKeys = ECPair.fromWIF('cQ4crx5qPv7NDdj41ehumfB9f89zyWdggy8JnNDjKVQwsLswahd4', Networks.bitcoinRegtest);
-export const btcAddress = 'msRY4KpAJ8o9da1YEASy1j2ACnuzh4SyFs';
+export const btcKeys = ECPair.fromWIF('Fpzo4qxGBizwddWz6hGgjgmKCVniWAWU1iPMHQuV8cgQHmxsRBB9', Networks.bitcoinSimnet);
+export const btcAddress = 'SbVnjfHyqqSJLd7eaEKKmw3xwsRLHG9cuh';
 
-export const ltcKeys = ECPair.fromWIF('cPnCzwHtVipcX7hb72mkkMMf4MSrknHbRnff2LDutSB8AxvxLaby', Networks.litecoinRegtest);
-export const ltcAddress = 'mysNm7METD1JffsC4E1ZW7EcPapmVm9AK4';
+export const ltcKeys = ECPair.fromWIF('FsTTuNURWqFsMpSLUXEkciAzYuBYibZB3r8ZoatdSpAjTznFUhnd', Networks.litecoinSimnet);
+export const ltcAddress = 'SSGEBiUF9kNdTR6wNqY8h7zgmacKo7PN6f';
 
 const host = process.platform === 'win32' ? '192.168.99.100' : 'localhost';
 
 export const btcdClient = new ChainClient(Logger.disabledLogger, {
   host,
-  port: 18334,
+  port: 18556,
   rpcuser: 'user',
   rpcpass: 'user',
   certpath: path.join('docker', 'data', 'rpc.cert'),
@@ -127,7 +130,7 @@ export const btcdClient = new ChainClient(Logger.disabledLogger, {
 
 export const ltcdClient = new ChainClient(Logger.disabledLogger, {
   host,
-  port: 19334,
+  port: 19556,
   rpcpass: 'user',
   rpcuser: 'user',
   certpath: path.join('docker', 'data', 'rpc.cert'),

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -4,16 +4,16 @@ services:
   btcd:
     image: michael1011/btcd
     ports:
-      - 18334:18334
+      - 18556:18556
 
-    command: --regtest --miningaddr msRY4KpAJ8o9da1YEASy1j2ACnuzh4SyFs
+    command: --simnet --miningaddr SbVnjfHyqqSJLd7eaEKKmw3xwsRLHG9cuh
 
   ltcd: 
     image: michael1011/ltcd
     ports:
-      - 19334:19334
+      - 19556:18556
 
-    command: --regtest --miningaddr mysNm7METD1JffsC4E1ZW7EcPapmVm9AK4
+    command: --simnet --miningaddr SSGEBiUF9kNdTR6wNqY8h7zgmacKo7PN6f
 
   lnd_btc1:
     image: michael1011/lnd
@@ -25,7 +25,7 @@ services:
     ports:
       - 10009:10009
 
-    command: --bitcoin.active --bitcoin.regtest --btcd.rpchost btcd:18334 --btcd.rpccert /rpc/rpc.cert --btcd.rpcuser user --btcd.rpcpass user
+    command: --bitcoin.active --bitcoin.simnet --btcd.rpchost btcd:18556 --btcd.rpccert /rpc/rpc.cert --btcd.rpcuser user --btcd.rpcpass user
 
   lnd_btc2:
     image: michael1011/lnd
@@ -36,4 +36,27 @@ services:
     ports:
       - 10010:10009
 
-    command: --bitcoin.active --bitcoin.regtest --btcd.rpchost btcd:18334 --btcd.rpccert /rpc/rpc.cert --btcd.rpcuser user --btcd.rpcpass user
+    command: --bitcoin.active --bitcoin.simnet --btcd.rpchost btcd:18556 --btcd.rpccert /rpc/rpc.cert --btcd.rpcuser user --btcd.rpcpass user
+
+  lnd_ltc1:
+    image: michael1011/lnd
+    links:
+      - ltcd
+      - lnd_ltc2:lnd
+    depends_on:
+      - ltcd
+    ports:
+      - 11009:10009
+
+    command: --litecoin.active --litecoin.simnet --ltcd.rpchost ltcd:18556 --ltcd.rpccert /rpc/rpc.cert --ltcd.rpcuser user --ltcd.rpcpass user
+
+  lnd_ltc2:
+    image: michael1011/lnd
+    links:
+      - ltcd
+    depends_on:
+      - ltcd
+    ports:
+      - 11010:10009
+
+    command: --litecoin.active --litecoin.simnet --ltcd.rpchost ltcd:18556 --ltcd.rpccert /rpc/rpc.cert --ltcd.rpcuser user --ltcd.rpcpass user

--- a/test/integration/lightning/LndClient.spec.ts
+++ b/test/integration/lightning/LndClient.spec.ts
@@ -2,24 +2,35 @@ import { expect } from 'chai';
 import path from 'path';
 import Logger from '../../../lib/Logger';
 import LndClient from '../../../lib/lightning/LndClient';
-import { btcdClient, btcManager } from '../chain/ChainClient.spec';
+import { UtxoManager, btcdClient, btcManager, ltcdClient, ltcManager } from '../chain/ChainClient.spec';
+import ChainClient from '../../../lib/chain/ChainClient';
 
 describe('LndClient', () => {
   before(async () => {
-    await btcdClient.connect();
+    await Promise.all([
+      btcdClient.connect(),
+      ltcdClient.connect(),
+    ]);
   });
 
   const channelCapacity = 10000000;
 
   let lndBtc2PubKey: string;
+  let lndLtc2PubKey: string;
 
   it('LndClients should connect', async () => {
-    await connectPromise();
+    await Promise.all([
+      connectPromise(lndBtcClient1, lndBtcClient2),
+      connectPromise(lndLtcClient1, lndLtcClient2),
+    ]);
+
     // Connect the LNDs to eachother
     const lndBtc2Info = await lndBtcClient2.getInfo();
+    const lndLtc2Info = await lndLtcClient2.getInfo();
 
     try {
       await lndBtcClient1.connectPeer(lndBtc2Info.identityPubkey, 'lnd:9735');
+      await lndLtcClient1.connectPeer(lndLtc2Info.identityPubkey, 'lnd:9735');
     } catch (error) {
       // Handle "already connected" errors gracefully
       if (!error.details.startsWith('already connected to peer:')) {
@@ -28,59 +39,81 @@ describe('LndClient', () => {
     }
 
     lndBtc2PubKey = lndBtc2Info.identityPubkey;
+    lndLtc2PubKey = lndLtc2Info.identityPubkey;
   });
 
   it('LndClients should fund get funds', async () => {
-    const btcAddress = await lndBtcClient1.newAddress();
-    const btcTxn = btcManager.constructTransaction(btcAddress.address, channelCapacity * 10);
+    const fundLndWallet = async (utxoManager: UtxoManager, lndClient: LndClient) => {
+      const addressResponse = await lndClient.newAddress();
+      const tx = utxoManager.constructTransaction(addressResponse.address, channelCapacity * 10);
 
-    await btcManager.broadcastAndMine(btcTxn.toHex());
+      await utxoManager.broadcastAndMine(tx.toHex());
+    };
 
-    await connectPromise();
+    await Promise.all([
+      fundLndWallet(btcManager, lndBtcClient1),
+      fundLndWallet(ltcManager, lndLtcClient1),
+    ]);
+
+    // Wait until the LNDs are in sync
+    await connectPromise(lndBtcClient1, lndBtcClient2);
+    await connectPromise(lndLtcClient1, lndLtcClient2);
   });
 
   it('LndClients should open a channel to eachother', async () => {
     expect(lndBtc2PubKey).to.not.be.undefined;
+    expect(lndLtc2PubKey).to.not.be.undefined;
 
-    const channelPromise = new Promise((resolve) => {
-      const interval = setInterval(async () => {
-        try {
-          await lndBtcClient1.openChannel(lndBtc2PubKey, channelCapacity, channelCapacity / 2),
-          await btcdClient.generate(1);
+    const openChannel = async (chainClient: ChainClient, lndClient: LndClient, remoteLndPubKey: string) => {
+      await new Promise((resolve) => {
+        const interval = setInterval(async () => {
+          try {
+            await lndClient.openChannel(remoteLndPubKey, channelCapacity, channelCapacity / 2),
+            await chainClient.generate(6);
 
-          clearInterval(interval);
-          resolve();
-        } catch (error) {
-          // Don't throw an error if the problem is LND not being synced yet
-          if (error.details !== 'channels cannot be created before the wallet is fully synced') {
-            throw error;
+            clearInterval(interval);
+            resolve();
+          } catch (error) {
+            // Don't throw an error if the problem is LND not being synced yet
+            if (error.details !== 'channels cannot be created before the wallet is fully synced') {
+              throw error;
+            }
           }
-        }
-      }, 500);
-    });
+        }, 500);
+      });
+    };
 
-    await channelPromise;
+    await Promise.all([
+      openChannel(btcdClient, lndBtcClient1, lndBtc2PubKey),
+      // openChannel(ltcdClient, lndLtcClient1, lndLtc2PubKey),
+    ]);
   });
 
   after(async () => {
-    await lndBtcClient1.disconnect();
-    await lndBtcClient2.disconnect();
+    await Promise.all([
+      lndBtcClient1.disconnect(),
+      lndBtcClient2.disconnect(),
 
-    await btcdClient.disconnect();
+      lndLtcClient1.disconnect(),
+      lndLtcClient2.disconnect(),
+
+      btcdClient.disconnect(),
+      ltcdClient.disconnect(),
+    ]);
   });
 });
 
-const connectPromise = async () => {
+const connectPromise = async (client1: LndClient, client2: LndClient) => {
   return new Promise(async (resolve) => {
-    await lndBtcClient1.connect();
-    await lndBtcClient2.connect();
+    await client1.connect();
+    await client2.connect();
 
     const interval = setInterval(async () => {
-      if (lndBtcClient1.isConnected() && lndBtcClient2.isConnected()) {
+      if (client1.isConnected() && client2.isConnected()) {
         // To make sure the LNDs are *really* synced
         try {
-          await lndBtcClient1.connectPeer('', '');
-          await lndBtcClient2.connectPeer('', '');
+          await client1.connectPeer('', '');
+          await client2.connectPeer('', '');
         } catch (error) {
           if (error.details === 'pubkey string is empty') {
             clearInterval(interval);
@@ -95,7 +128,6 @@ const connectPromise = async () => {
 const certpath = path.join('docker', 'data', 'lnd', 'tls.cert');
 const host = process.platform === 'win32' ? '192.168.99.100' : 'localhost';
 
-// TODO: the logger shouldn't print anything
 export const lndBtcClient1 = new LndClient(Logger.disabledLogger, {
   certpath,
   host,
@@ -107,5 +139,19 @@ export const lndBtcClient2 = new LndClient(Logger.disabledLogger, {
   certpath,
   host,
   port: 10010,
+  macaroonpath: '',
+}, 'LTC');
+
+export const lndLtcClient1 = new LndClient(Logger.disabledLogger, {
+  certpath,
+  host,
+  port: 11009,
+  macaroonpath: '',
+}, 'LTC');
+
+export const lndLtcClient2 = new LndClient(Logger.disabledLogger, {
+  certpath,
+  host,
+  port: 11010,
   macaroonpath: '',
 }, 'LTC');

--- a/test/integration/swap/Submarine.spec.ts
+++ b/test/integration/swap/Submarine.spec.ts
@@ -20,7 +20,7 @@ describe('Submarine Swaps', () => {
     const { blocks } = await btcdClient.getInfo();
 
     const redeemScript = pkRefundSwap(preimageHash, swapKeys.publicKey, btcKeys.publicKey, blocks + 1000);
-    const swapAddress = address.fromOutputScript(outputFunction(redeemScript), Networks.bitcoinRegtest);
+    const swapAddress = address.fromOutputScript(outputFunction(redeemScript), Networks.bitcoinSimnet);
 
     const transaction = btcManager.constructTransaction(swapAddress, 10000);
     await btcManager.broadcastAndMine(transaction.toHex());
@@ -35,7 +35,7 @@ describe('Submarine Swaps', () => {
       value: transactionOutput.value,
     };
 
-    const destinationScript = address.toOutputScript(btcAddress, Networks.bitcoinRegtest);
+    const destinationScript = address.toOutputScript(btcAddress, Networks.bitcoinSimnet);
     const claimTransaction = constructClaimTransaction(
       preimage,
       swapKeys,

--- a/test/integration/wallet/Wallet.spec.ts
+++ b/test/integration/wallet/Wallet.spec.ts
@@ -30,7 +30,7 @@ describe('Wallet', () => {
     walletRepository,
     utxoRepository,
     masterNode,
-    Networks.bitcoinRegtest,
+    Networks.bitcoinSimnet,
     btcdClient,
     derivationPath,
     highestUsedIndex,


### PR DESCRIPTION
Closes #81 

This commits changes the network of the integration tests from regtest to simnet and adds two LNDs on Litecoin to `LndClient.spec.ts`. Because the current version of LND is not compatible with the Litecoin simnet I switched to a branch of the ExchangeUnion fork of LND for the Docker image of LND I switched to a [branch of the ExchangeUnion fork of LND](https://github.com/ExchangeUnion/lnd/tree/resolver%2Bsimnet-ltcd) for the Docker image of LND.