### PR TITLE
refactor: switch from SHA256 to HASH160 opcode

### DIFF
--- a/lib/swap/SwapManager.ts
+++ b/lib/swap/SwapManager.ts
@@ -74,7 +74,7 @@ class SwapManager {
    * @param pairId pair of the Swap
    * @param orderSide whether the order is a buy or sell one
    * @param invoice the invoice that should be paid
-   * @param refundPublicKey the public key for the refund
+   * @param refundPublicKey public key of the keypair needed for claiming
    * @param outputType what kind of adress should be returned
    *
    * @returns an onchain address
@@ -124,7 +124,7 @@ class SwapManager {
    *
    * @param pairId pair of the Swap
    * @param orderSide whether the order is a buy or sell one
-   * @param claimPublicKey the public key of the private key needed for the claiming
+   * @param claimPublicKey public key of the keypair needed for claiming
    * @param amount the amount of the invoice
    *
    * @returns a Lightning invoice, the lockup transaction and its hash

--- a/test/unit/swap/Submarine.spec.ts
+++ b/test/unit/swap/Submarine.spec.ts
@@ -16,7 +16,7 @@ describe('SubmarineSwaps', () => {
         timeoutBlockHeight,
         refundPublicKey: getHexBuffer('03ec0c1e45b709d708cd376a6f2daf19ac27be229647780d592e27d7fb7efb207a'),
       },
-      result: 'a82053ada8e6de01c26ff43040887ba7b22bddce19f8658fd1ba00716ed79d15cd5e87632103f8109578aae1e5cfc497e466cf6ae6625497cd31886e87b2f4f54f3f0f46b539670354df07b1752103ec0c1e45b709d708cd376a6f2daf19ac27be229647780d592e27d7fb7efb207a68ac',
+      result: 'a914e2ac8cb97af3d59b1c057db4b0c4f9aa12a9127387632103f8109578aae1e5cfc497e466cf6ae6625497cd31886e87b2f4f54f3f0f46b539670354df07b1752103ec0c1e45b709d708cd376a6f2daf19ac27be229647780d592e27d7fb7efb207a68ac',
     };
 
     const result = pkRefundSwap(
@@ -37,7 +37,7 @@ describe('SubmarineSwaps', () => {
         timeoutBlockHeight,
         refundPublicKeyHash: getHexBuffer('10fd1a974109be99bdf95334f8b7625bda0e90be'),
       },
-      result: '76a82053ada8e6de01c26ff43040887ba7b22bddce19f8658fd1ba00716ed79d15cd5e8763752103f8109578aae1e5cfc497e466cf6ae6625497cd31886e87b2f4f54f3f0f46b539670354df07b17576a91410fd1a974109be99bdf95334f8b7625bda0e90be8868ac',
+      result: '76a914e2ac8cb97af3d59b1c057db4b0c4f9aa12a912738763752103f8109578aae1e5cfc497e466cf6ae6625497cd31886e87b2f4f54f3f0f46b539670354df07b17576a91410fd1a974109be99bdf95334f8b7625bda0e90be8868ac',
     };
 
     const result = pkHashRefundSwap(


### PR DESCRIPTION
This commit switches from the SHA256 to the HASH160 opcode which means that not a 256 bit SHA256 hash but a 160 bit RIPEMD160 hash will be stored on the chain. This results in 12 byte smaller lockup, claim and refund transactions.