### PR TITLE
feat: add BIP21 to createswap

### DIFF
--- a/lib/cli/Command.ts
+++ b/lib/cli/Command.ts
@@ -5,7 +5,7 @@ import { Arguments } from 'yargs';
 import { getServiceDataDir } from '../Utils';
 import { XchangeClient } from '../proto/xchangerpc_grpc_pb';
 
-interface GrpcResponse {
+export interface GrpcResponse {
   toObject: Function;
 }
 
@@ -18,13 +18,21 @@ export const loadXchangeClient = (argv: Arguments): XchangeClient => {
 
 export const callback = (error: Error | null, response: GrpcResponse) => {
   if (error) {
-    console.error(`${error.name}: ${error.message}`);
+    printError(error);
   } else {
     const responseObj = response.toObject();
     if (Object.keys(responseObj).length === 0) {
       console.log('success');
     } else {
-      console.log(JSON.stringify(responseObj, undefined, 2));
+      printResponse(responseObj);
     }
   }
+};
+
+export const printResponse = (response: any) => {
+  console.log(JSON.stringify(response, undefined, 2));
+};
+
+export const printError = (error: Error) => {
+  console.error(`${error.name}: ${error.message}`);
 };

--- a/lib/cli/commands/CreateSwap.ts
+++ b/lib/cli/commands/CreateSwap.ts
@@ -1,10 +1,11 @@
 import { Arguments } from 'yargs';
-import { callback, loadXchangeClient } from '../Command';
+import * as qrcode from 'qrcode-terminal';
+import { loadXchangeClient, GrpcResponse, printError, printResponse } from '../Command';
 import { OutputTypeComponent, OrderSideComponent } from '../BuilderComponents';
 import { CreateSwapRequest } from '../../proto/xchangerpc_pb';
 import { getOutputType, getOrderSide } from '../Utils';
 
-export const command = 'createswap <pair_id> <order_side> <invoice> [output_type] [refund_public_key]';
+export const command = 'createswap <pair_id> <order_side> <invoice> [output_type] [refund_public_key] [show_qr]';
 
 export const describe = 'create a new swap from the chain to Lightning';
 
@@ -23,6 +24,27 @@ export const builder = {
     describe: 'public key with which a refund transaction has to be signed',
     type: 'string',
   },
+  show_qr: {
+    describe: 'whether a QR code for the BIP21 payment request',
+    type: 'boolean',
+  },
+};
+
+let showQr = false;
+
+export const callback = (error: Error | null, response: GrpcResponse) => {
+  if (error) {
+    printError(error);
+  } else {
+    const responseObj = response.toObject();
+
+    printResponse(responseObj);
+
+    if (showQr) {
+      console.log();
+      qrcode.generate(responseObj.bip21, { small: true });
+    }
+  }
 };
 
 export const handler = (argv: Arguments) => {
@@ -33,6 +55,8 @@ export const handler = (argv: Arguments) => {
   request.setInvoice(argv.invoice);
   request.setOutputType(getOutputType(argv.output_type));
   request.setRefundPublicKey(argv.refund_public_key);
+
+  showQr = argv.show_qr;
 
   loadXchangeClient(argv).createSwap(request, callback);
 };

--- a/lib/grpc/GrpcService.ts
+++ b/lib/grpc/GrpcService.ts
@@ -118,10 +118,12 @@ class GrpcService {
 
   public createSwap: grpc.handleUnaryCall<xchangerpc.CreateSwapRequest, xchangerpc.CreateSwapResponse> = async (call, callback) => {
     try {
-      const address = await this.service.createSwap(call.request.toObject());
+      const { address, expectedAmount, bip21 } = await this.service.createSwap(call.request.toObject());
 
       const response = new xchangerpc.CreateSwapResponse();
       response.setAddress(address);
+      response.setExpectedAmount(expectedAmount);
+      response.setBip21(bip21);
 
       callback(null, response);
     } catch (error) {

--- a/lib/proto/xchangerpc_pb.d.ts
+++ b/lib/proto/xchangerpc_pb.d.ts
@@ -361,6 +361,12 @@ export class CreateSwapResponse extends jspb.Message {
     getAddress(): string;
     setAddress(value: string): void;
 
+    getExpectedAmount(): number;
+    setExpectedAmount(value: number): void;
+
+    getBip21(): string;
+    setBip21(value: string): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CreateSwapResponse.AsObject;
@@ -375,6 +381,8 @@ export class CreateSwapResponse extends jspb.Message {
 export namespace CreateSwapResponse {
     export type AsObject = {
         address: string,
+        expectedAmount: number,
+        bip21: string,
     }
 }
 

--- a/lib/proto/xchangerpc_pb.js
+++ b/lib/proto/xchangerpc_pb.js
@@ -2451,7 +2451,9 @@ proto.xchangerpc.CreateSwapResponse.prototype.toObject = function(opt_includeIns
  */
 proto.xchangerpc.CreateSwapResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
-    address: jspb.Message.getFieldWithDefault(msg, 1, "")
+    address: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    expectedAmount: jspb.Message.getFieldWithDefault(msg, 2, 0),
+    bip21: jspb.Message.getFieldWithDefault(msg, 3, "")
   };
 
   if (includeInstance) {
@@ -2492,6 +2494,14 @@ proto.xchangerpc.CreateSwapResponse.deserializeBinaryFromReader = function(msg, 
       var value = /** @type {string} */ (reader.readString());
       msg.setAddress(value);
       break;
+    case 2:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setExpectedAmount(value);
+      break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setBip21(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -2528,6 +2538,20 @@ proto.xchangerpc.CreateSwapResponse.serializeBinaryToWriter = function(message, 
       f
     );
   }
+  f = message.getExpectedAmount();
+  if (f !== 0) {
+    writer.writeInt64(
+      2,
+      f
+    );
+  }
+  f = message.getBip21();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
 };
 
 
@@ -2543,6 +2567,36 @@ proto.xchangerpc.CreateSwapResponse.prototype.getAddress = function() {
 /** @param {string} value */
 proto.xchangerpc.CreateSwapResponse.prototype.setAddress = function(value) {
   jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional int64 expected_amount = 2;
+ * @return {number}
+ */
+proto.xchangerpc.CreateSwapResponse.prototype.getExpectedAmount = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
+};
+
+
+/** @param {number} value */
+proto.xchangerpc.CreateSwapResponse.prototype.setExpectedAmount = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional string bip21 = 3;
+ * @return {string}
+ */
+proto.xchangerpc.CreateSwapResponse.prototype.getBip21 = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.xchangerpc.CreateSwapResponse.prototype.setBip21 = function(value) {
+  jspb.Message.setField(this, 3, value);
 };
 
 

--- a/lib/swap/SwapUtils.ts
+++ b/lib/swap/SwapUtils.ts
@@ -8,25 +8,7 @@ import Bn from 'bn.js';
 import * as varuint from 'varuint-bitcoin';
 import { getHexBuffer, getHexString } from '../Utils';
 import { ScriptElement } from '../consts/Types';
-
-const inBits = 5;
-const outBits = 8;
-const trimByteLength = 1;
-
-const bigTen = new Bn(10, 10);
-
-const tokenDivisibility = new Bn(1e8, 10);
-const divisibilityMarkerLen = 1;
-const maxMilliTokens = '2100000000000000';
-const maxTokenDivisibility = 3;
-const noDecimals = '000';
-const decBase = 10;
-const divisors = {
-  m: '1000',
-  n: '1000000000',
-  p: '1000000000000',
-  u: '1000000',
-};
+import { Currency } from '../wallet/WalletManager';
 
 /**
  * DER encode bytes to eliminate sign confusion in a big-endian number
@@ -121,108 +103,22 @@ export const toPushdataScript = (elements: ScriptElement[]): Buffer => {
   return Buffer.concat(buffers);
 };
 
-/*
 /**
- * Decode bech32 encoded words to bytes
+ * Gets the BIP21 prefix for a currency
  */
-export const wordsToBuffer = (words: Buffer, trim = false) => {
-  let bits = 0;
-  const maxV = (1 << outBits) - 1;
-  const result: number[] = [];
-  let value = 0;
-
-  for (let i = 0; i < words.length; i += 1) {
-    value = (value << inBits) | words[i];
-    bits += inBits;
-
-    while (bits >= outBits) {
-      bits -= outBits;
-
-      result.push((value >> bits) & maxV);
-    }
-  }
-
-  if (bits > 0) {
-    result.push((value << (outBits - bits)) & maxV);
-  }
-
-  if (trim && words.length * inBits % outBits !== 0) {
-    return Buffer.from(result).slice(0, -trimByteLength);
-  } else {
-    return Buffer.from(result);
-  }
+export const getBip21Prefix = (currency: Currency) => {
+  return currency.symbol === 'BTC' ? 'bitcoin' : 'litecoin';
 };
 
-/** Convert words to a big endian number */
-export const wordsToNumber = (words: Buffer) => {
-  return words.reverse().reduce((sum, n, i) => sum + n * Math.pow(32, i), 0);
-};
+/**
+ * Encode a BIP21 payment request
+ */
+export const encodeBip21 = (prefix: string, address: string, satoshis: number, label?: string) => {
+  let request = `${prefix}:${address}?value=${satoshis / 100000000}`;
 
-const dividedRemainder = (div: Bn, max: number, modArg: any) => {
-  let mod = modArg;
-
-  return Array.from({ length: max }).reduce((accumulator) => {
-    const bigDiv = mod.mul(bigTen).divmod(div);
-
-    mod = bigDiv.mod;
-
-    return accumulator + bigDiv.div.toString();
-  }, '');
-};
-
-/** Get the nuber of tokens from a bech32 "HRP" */
-export const hrpToTokens = (hrp: string) => {
-  let decimals;
-  let divisor;
-  let tokens;
-  let value;
-
-  if (hrp.slice(-divisibilityMarkerLen).match(/^[munp]$/)) {
-    divisor = hrp.slice(-divisibilityMarkerLen);
-    value = hrp.slice(0, -divisibilityMarkerLen);
-  } else if (hrp.slice(-divisibilityMarkerLen).match(/^[^munp0-9]$/)) {
-    throw new Error('InvalidAmountMultiplier');
-  } else {
-    value = hrp;
+  if (label) {
+    request += `&label=${label.replace(/ /g, '%20')}`;
   }
 
-  if (!value.match(/^\d+$/)) {
-    throw new Error('InvalidAmount');
-  }
-
-  const val = new Bn(value, decBase);
-
-  // HRPs can encode values smaller than tokens on the chain can represent
-  if (!!divisor) {
-    const div = new Bn(divisors[divisor], decBase);
-
-    const divmod = val.mul(tokenDivisibility).divmod(div);
-    const max = maxTokenDivisibility;
-
-    const isMilliTokens = divmod.mod.toString() !== '0';
-    const { mod } = divmod;
-
-    decimals = !isMilliTokens ? noDecimals : dividedRemainder(div, mod, max);
-    tokens = divmod.div;
-  } else {
-    decimals = noDecimals;
-    tokens = val.mul(tokenDivisibility);
-  }
-
-  if (tokens.gt(new Bn(maxMilliTokens, decBase))) {
-    throw new Error('TokenCountExceedsMaximumValue');
-  }
-
-  return {
-    mtokens: `${tokens.toString()}${decimals}`,
-    tokens: tokens.toNumber(),
-  };
-};
-
-/** Get the expiration time of an invoice bases on its creation time */
-export const getInvoiceExpiration = (createdAt: string, words?: Buffer) => {
-  const createdAtMs = Date.parse(createdAt);
-  const secondsToAdd = !words ? 3600 : wordsToNumber(words);
-
-  return new Date(createdAtMs + secondsToAdd * 1e3).toISOString();
+  return request;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5705,6 +5705,11 @@
         "bitcoin-ops": "^1.3.0"
       }
     },
+    "qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "grpc": "^1.16.0",
     "ini": "^1.3.5",
     "node-forge": "^0.7.6",
+    "qrcode-terminal": "^0.12.0",
     "sequelize": "^4.41.0",
     "sqlite3": "^4.0.3",
     "toml": "^2.3.3",

--- a/proto/xchangerpc.proto
+++ b/proto/xchangerpc.proto
@@ -96,6 +96,8 @@ message CreateSwapRequest {
 }
 message CreateSwapResponse {
   string address = 1;
+  int64 expected_amount = 2;
+  string bip21 = 3;
 }
 
 message CreateReverseSwapRequest {


### PR DESCRIPTION
Closes #108 

This commit adds BIP21 payment requests and QR codes for them to the `createswap` command. This will improve the UX when testing swaps on testnet or mainnet with traditional or mobile wallets.

To show the QR code when creating a Swap:
```
xchange-cli createswap LTC/BTC sell <invoice> --show_qr
```